### PR TITLE
gemspec: Drop unused configuration about executables

### DIFF
--- a/rinda.gemspec
+++ b/rinda.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "drb"


### PR DESCRIPTION
This gem does not expose any executables.